### PR TITLE
Potential fix for code scanning alert no. 4: Type confusion through parameter tampering

### DIFF
--- a/backend/src/routes/music.ts
+++ b/backend/src/routes/music.ts
@@ -143,7 +143,13 @@ router.get(
   authMiddleware,
   async (req, res, next) => {
     try {
-      const query = req.query.q as string;
+      const rawQuery = req.query.q;
+      const query =
+        typeof rawQuery === 'string'
+          ? rawQuery
+          : Array.isArray(rawQuery)
+            ? (rawQuery[0] ?? '')
+            : '';
 
       if (!query || query.length < 2) {
         res.json({


### PR DESCRIPTION
Potential fix for [https://github.com/aprameyak/MusIQ/security/code-scanning/4](https://github.com/aprameyak/MusIQ/security/code-scanning/4)

In general, to fix this class of problem you should not assume query parameters are strings; instead, you must validate their runtime type before using string methods or relying on their semantics. If the value can legally be multi-valued, normalize it (for example, by taking the first value or joining with a delimiter); otherwise, reject non-string types as invalid input.

For this specific route in `backend/src/routes/music.ts`, the best, minimal-impact fix is:

- Retrieve `req.query.q` as `unknown | string | string[]`.
- If it is an array, normalize it to a string (for example, take the first non-empty element); if it is not a string, treat it as missing/invalid and return an empty result.
- Only then apply the `length` check and construct the SQL parameter.

This preserves existing behavior for normal, single-valued `q` parameters while preventing subtle bypasses of the “length < 2 ⇒ return empty data” condition via arrays. Concretely:

- Replace `const query = req.query.q as string;` with a small normalization block that:
  - Handles `undefined` and empty string as before.
  - If `Array.isArray(rawQuery)`, picks the first element `rawQuery[0]` (or `''` if none).
  - Ensures the resulting `query` is a string.
- Keep the rest of the logic the same, now operating on a guaranteed string.

No new imports are needed; we can use `Array.isArray`, which is built-in.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
