### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/backend/src/security/identity-federation.ts
+++ b/backend/src/security/identity-federation.ts
@@ -122,7 +122,7 @@ export class IdentityFederationService {
       [newUser.id, tokens.refreshToken]
     );
 
-    logger.info('OAuth user created', { userId: newUser.id, provider: oauthUser.provider });
+    logger.info('OAuth user created', { userId: newUser.id });
     return { user: newUser, tokens };
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/aprameyak/MusIQ/security/code-scanning/3](https://github.com/aprameyak/MusIQ/security/code-scanning/3)

In general, to fix clear-text logging of sensitive information, remove or redact any fields that originate from untrusted or sensitive sources (OAuth payloads, tokens, PII) before logging. Only log non-sensitive metadata that does not reveal user identity or secrets. If some detail is necessary for debugging, either log an internal, non-user-specific code or ensure logs are properly restricted and, ideally, anonymized.

Here, the reported issue is that `oauthUser.provider` (derived from an OAuth request) is logged. The safest minimal change, without altering functionality, is to stop logging the `provider` value coming from `oauthUser`. We can still keep a useful log by logging only the internal user ID (which comes from the database row), or by using a constant provider string if needed (but that adds little value). Therefore, we should change line 125 to log either only the `userId`, or to move the `provider` detail into the static message without pulling it from `oauthUser`. The simplest and cleanest change is to log only `userId: newUser.id`.

Concretely:
- In `backend/src/security/identity-federation.ts`, update the `logger.info` call near line 125.
- Replace `logger.info('OAuth user created', { userId: newUser.id, provider: oauthUser.provider });` with `logger.info('OAuth user created', { userId: newUser.id });`.
- No new imports, methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
