### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend-ci-cd.yml
+++ b/.github/workflows/backend-ci-cd.yml
@@ -15,6 +15,9 @@ on:
       - '.github/workflows/backend-ci-cd.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: '20.x'
 


### PR DESCRIPTION
Potential fix for [https://github.com/aprameyak/MusIQ/security/code-scanning/2](https://github.com/aprameyak/MusIQ/security/code-scanning/2)

In general, the fix is to explicitly declare a `permissions` block so the default `GITHUB_TOKEN` permissions are minimized instead of inheriting possibly broad repository defaults. Since this workflow only needs to check out code and does not interact with GitHub in a way that requires write access, we can safely set `contents: read` for the entire workflow, or even `permissions: {}` (no permissions) if we want to harden further and are sure no step requires the token. A common, clear baseline is `contents: read` at the root level so all jobs inherit it.

The single best change here with minimal functional risk is to add a top‑level `permissions:` block after the `on:` section (e.g., after line 16) so it applies to both `ci` and `deploy` jobs. We’ll set `contents: read`, which allows checkout to work in all typical organization configurations while still removing write capabilities and other scopes. No imports or additional definitions are needed, just the YAML keys.

Concretely, in `.github/workflows/backend-ci-cd.yml`, insert:

```yaml
permissions:
  contents: read
```

at the root level, aligned with `name`, `on`, `env`, and `jobs`. No other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
