### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend-ci-cd.yml
+++ b/.github/workflows/backend-ci-cd.yml
@@ -15,6 +15,9 @@ on:
       - '.github/workflows/backend-ci-cd.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: '20.x'
 


### PR DESCRIPTION
Potential fix for [https://github.com/aprameyak/MusIQ/security/code-scanning/1](https://github.com/aprameyak/MusIQ/security/code-scanning/1)

In general, to fix this class of issue you explicitly declare a `permissions:` block either at the workflow root (applies to all jobs unless overridden) or per job, granting only the scopes actually needed. For a build-and-deploy workflow that only checks out code, runs Node commands, and deploys over SSH using secrets, the GITHUB_TOKEN needs only read access to repository contents.

The single best fix here is to add a workflow‑level `permissions:` block just after the `on:` block and before `env:`. This will apply to both `ci` and `deploy` jobs. The minimal safe starting point matching CodeQL’s suggestion is:

```yaml
permissions:
  contents: read
```

No existing steps rely on write operations to the repo or other GitHub resources, so this change will not alter current behavior aside from tightening security. No extra methods, imports, or definitions are required since this is purely a YAML configuration change inside `.github/workflows/backend-ci-cd.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
